### PR TITLE
Closes #65 Address model checkpoint corruption during multi-GPU training sessions

### DIFF
--- a/__code2/CollaborativeFilteringTests.cs
+++ b/__code2/CollaborativeFilteringTests.cs
@@ -1,0 +1,93 @@
+using Algorithms.RecommenderSystem;
+using Moq;
+
+namespace Algorithms.Tests.RecommenderSystem;
+
+[TestFixture]
+public class CollaborativeFilteringTests
+{
+    private Mock<ISimilarityCalculator>? mockSimilarityCalculator;
+    private CollaborativeFiltering? recommender;
+    private Dictionary<string, Dictionary<string, double>> testRatings = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        mockSimilarityCalculator = new Mock<ISimilarityCalculator>();
+        recommender = new CollaborativeFiltering(mockSimilarityCalculator.Object);
+
+        testRatings = new Dictionary<string, Dictionary<string, double>>
+        {
+            ["user1"] = new()
+            {
+                ["item1"] = 5.0,
+                ["item2"] = 3.0,
+                ["item3"] = 4.0
+            },
+            ["user2"] = new()
+            {
+                ["item1"] = 4.0,
+                ["item2"] = 2.0,
+                ["item3"] = 5.0
+            },
+            ["user3"] = new()
+            {
+                ["item1"] = 3.0,
+                ["item2"] = 4.0,
+                ["item4"] = 3.0
+            }
+        };
+    }
+
+    [Test]
+    [TestCase("item1", 4.0, 5.0)]
+    [TestCase("item2", 2.0, 4.0)]
+    public void CalculateSimilarity_WithValidInputs_ReturnsExpectedResults(
+        string commonItem,
+        double rating1,
+        double rating2)
+    {
+        var user1Ratings = new Dictionary<string, double> { [commonItem] = rating1 };
+        var user2Ratings = new Dictionary<string, double> { [commonItem] = rating2 };
+
+        var similarity = recommender?.CalculateSimilarity(user1Ratings, user2Ratings);
+
+        Assert.That(similarity, Is.InRange(-1.0, 1.0));
+    }
+
+    [Test]
+    public void CalculateSimilarity_WithNoCommonItems_ReturnsZero()
+    {
+        var user1Ratings = new Dictionary<string, double> { ["item1"] = 5.0 };
+        var user2Ratings = new Dictionary<string, double> { ["item2"] = 4.0 };
+
+        var similarity = recommender?.CalculateSimilarity(user1Ratings, user2Ratings);
+
+        Assert.That(similarity, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void PredictRating_WithNonexistentItem_ReturnsZero()
+    {
+        var predictedRating = recommender?.PredictRating("nonexistentItem", "user1", testRatings);
+
+        Assert.That(predictedRating, Is.EqualTo(0));
+    }
+
+    [NonParallelizable]
+    [Test]
+    public void PredictRating_WithOtherUserHavingRatedTargetItem_ShouldCalculateSimilarityAndWeightedSum()
+    {
+        var targetItem = "item1";
+        var targetUser = "user1";
+
+        mockSimilarityCalculator?
+            .Setup(s => s.CalculateSimilarity(It.IsAny<Dictionary<string, double>>(), It.IsAny<Dictionary<string, double>>()))
+            .Returns(0.8);
+
+        var predictedRating = recommender?.PredictRating(targetItem, targetUser, testRatings);
+
+        Assert.That(predictedRating, Is.Not.EqualTo(0.0d));
+        Assert.That(predictedRating, Is.EqualTo(3.5d).Within(0.01));
+    }
+}

--- a/__code2/ImmutableHashMapTest.java
+++ b/__code2/ImmutableHashMapTest.java
@@ -1,0 +1,55 @@
+package com.thealgorithms.datastructures.hashmap.hashing;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class ImmutableHashMapTest {
+
+    @Test
+    void testEmptyMap() {
+        ImmutableHashMap<String, Integer> map = ImmutableHashMap.<String, Integer>empty();
+
+        assertEquals(0, map.size());
+        assertNull(map.get("A"));
+    }
+
+    @Test
+    void testPutDoesNotModifyOriginalMap() {
+        ImmutableHashMap<String, Integer> map1 = ImmutableHashMap.<String, Integer>empty();
+
+        ImmutableHashMap<String, Integer> map2 = map1.put("A", 1);
+
+        assertEquals(0, map1.size());
+        assertEquals(1, map2.size());
+        assertNull(map1.get("A"));
+        assertEquals(1, map2.get("A"));
+    }
+
+    @Test
+    void testMultiplePuts() {
+        ImmutableHashMap<String, Integer> map = ImmutableHashMap.<String, Integer>empty().put("A", 1).put("B", 2);
+
+        assertEquals(2, map.size());
+        assertEquals(1, map.get("A"));
+        assertEquals(2, map.get("B"));
+    }
+
+    @Test
+    void testContainsKey() {
+        ImmutableHashMap<String, Integer> map = ImmutableHashMap.<String, Integer>empty().put("X", 100);
+
+        assertTrue(map.containsKey("X"));
+        assertFalse(map.containsKey("Y"));
+    }
+
+    @Test
+    void testNullKey() {
+        ImmutableHashMap<String, Integer> map = ImmutableHashMap.<String, Integer>empty().put(null, 50);
+
+        assertEquals(50, map.get(null));
+    }
+}

--- a/__code2/OuncesToKilogram.test.js
+++ b/__code2/OuncesToKilogram.test.js
@@ -1,0 +1,5 @@
+import ouncesToKilograms from '../OuncesToKilograms'
+
+test('Convert 60 ounces to kilograms', () => {
+  expect(parseFloat(ouncesToKilograms(60).toFixed(3))).toBe(1.701)
+})


### PR DESCRIPTION
65 Several outdated examples have been updated to match the current configuration schema. Deprecated parameters were removed from docs to avoid misleading users. The changes aim to improve onboarding experience.